### PR TITLE
OSCI: Push images

### DIFF
--- a/.openshift-ci-migration/migrate.sh
+++ b/.openshift-ci-migration/migrate.sh
@@ -29,4 +29,4 @@ fi
 # Handoff to target repo dispatch
 .openshift-ci/dispatch.sh "$*"
 
-info "nothing to see here either"
+info "nothing to see in stackrox-osci either"

--- a/.openshift-ci-migration/migrate.sh
+++ b/.openshift-ci-migration/migrate.sh
@@ -26,12 +26,6 @@ if [[ "$head_ref" != "null" ]]; then
     git checkout "$head_ref"
 fi
 
-# make deps as a tire kick
-make deps
-
-# there is no build in OSCI yet, so hard code a known good one for migration
-echo "3.69.x-310-g23ca4e5107" > CI_TAG
-
 # Handoff to target repo dispatch
 .openshift-ci/dispatch.sh "$*"
 


### PR DESCRIPTION
Companion to https://github.com/stackrox/stackrox/pull/1506. A static tag is no longer required.