### PR TITLE
OWNERS testing

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,4 @@
 approvers:
 - gavin-stackrox
-- sbostick
 reviewers:
 - gavin-stackrox
-- sbostick

--- a/README.md
+++ b/README.md
@@ -5,4 +5,3 @@ stackrox/stackrox.
 
 OpenShift CI: https://github.com/openshift/release
 Configuration for StackRox: https://github.com/openshift/release/tree/master/ci-operator/config/stackrox
-

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ stackrox/stackrox.
 
 OpenShift CI: https://github.com/openshift/release
 Configuration for StackRox: https://github.com/openshift/release/tree/master/ci-operator/config/stackrox
+


### PR DESCRIPTION
Remove @sbostick from OWNERS to test its relevance.

I expect that:
- This will remove sbostick from stackrox-osci OWNERS files when the OSCI jobs run.
- This will not remove sbostick from stackrox org level OWNERS files.
  - And so sbostick can still `/lgtm` PRs in openshift/release.
- sbostick can still create PRs and run tests in stackrox-osci.