### PR TITLE
OSCI: test optional jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ stackrox/stackrox.
 OpenShift CI: https://github.com/openshift/release
 Configuration for StackRox: https://github.com/openshift/release/tree/master/ci-operator/config/stackrox
 
+


### PR DESCRIPTION
When jobs (tests) fail they all show as 'required' in the openshift CI bot message. This is confusing as it does not match what we set with GitHub branch protection. This PR uses the stackrox-osci repo to see if optional: true does what we want i.e. fixes the table and runs the job.

From https://github.com/openshift/release/pull/28320 gke-qa-e2e-tests is now optional, lets see how it goes.
